### PR TITLE
fix: the tools-delete in tools-delete.js

### DIFF
--- a/plugins/tools-delete.js
+++ b/plugins/tools-delete.js
@@ -16,6 +16,7 @@ let handler = async (m, { conn, command }) => {
 };
 handler.help = ['del', 'delete'];
 handler.tags = ['tools'];
+handler.admin = true;
 handler.botaadmin = true;
 handler.command = ['del', 'delete', 'unsend'];
 


### PR DESCRIPTION
## Summary
Fix high severity security issue in `plugins/tools-delete.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `plugins/tools-delete.js:1` |
| **Assessment** | Likely exploitable |

**Description**: The tools-delete.js plugin allows any WhatsApp user to delete messages without authorization checks. While the bot must be admin in the group, there is no verification that the user invoking the command has admin privileges, enabling any group member to delete arbitrary messages.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `plugins/tools-delete.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
